### PR TITLE
[orchagent] Fix typo in PortsOrch::initPortSupportedSpeeds

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -1713,7 +1713,7 @@ void PortsOrch::getPortSupportedSpeeds(const std::string& alias, sai_object_id_t
 
 void PortsOrch::initPortSupportedSpeeds(const std::string& alias, sai_object_id_t port_id)
 {
-    // if port supported speeds map already contains the information, save the SAI call
+    // If port supported speeds map already contains the information, save the SAI call
     if (m_portSupportedSpeeds.count(port_id))
     {
         return;

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -1713,7 +1713,8 @@ void PortsOrch::getPortSupportedSpeeds(const std::string& alias, sai_object_id_t
 
 void PortsOrch::initPortSupportedSpeeds(const std::string& alias, sai_object_id_t port_id)
 {
-    if (!m_portSupportedSpeeds.count(port_id))
+    // if port supported speeds map already contains the information, save the SAI call
+    if (m_portSupportedSpeeds.count(port_id))
     {
         return;
     }


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

Fix typo in PortsOrch::initPortSupportedSpeeds

**Why I did it**

It stop orchagent from getting supported port speed from SAI

**How I verified it**

Manual test

**Details if related**
