### PR TITLE
[orchagent] Put port configuration to APPL_DB according to autoneg mode

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -2507,26 +2507,23 @@ void PortsOrch::doPortTask(Consumer &consumer)
                 {
                     an_str = fvValue(i);
                 }
-
                 /* Set advertised speeds */
-                if (fvField(i) == "adv_speeds")
+                else if (fvField(i) == "adv_speeds")
                 {
                     adv_speeds_str = fvValue(i);
                 }
-
                 /* Set interface type */
-                if (fvField(i) == "interface_type")
+                else if (fvField(i) == "interface_type")
                 {
                     interface_type_str = fvValue(i);
                 }
-
                 /* Set advertised interface type */
-                if (fvField(i) == "adv_interface_types")
+                else if (fvField(i) == "adv_interface_types")
                 {
                     adv_interface_types_str = fvValue(i);
                 }
                 /* Set port serdes Pre-emphasis */
-                if (fvField(i) == "preemphasis")
+                else if (fvField(i) == "preemphasis")
                 {
                     getPortSerdesVal(fvValue(i), attr_val);
                     serdes_attr.insert(serdes_attr_pair(SAI_PORT_SERDES_ATTR_PREEMPHASIS, attr_val));

--- a/portsyncd/portsyncd.cpp
+++ b/portsyncd/portsyncd.cpp
@@ -235,6 +235,10 @@ bool handlePortConfigFromConfigDB(ProducerStateTable &p, DBConnector &cfgDb, boo
 
 void handlePortConfig(ProducerStateTable &p, map<string, KeyOpFieldsValuesTuple> &port_cfg_map)
 {
+    string autoneg;
+    vector<FieldValueTuple> attrs;
+    vector<FieldValueTuple> autoneg_attrs;
+    vector<FieldValueTuple> force_attrs;
 
     auto it = port_cfg_map.begin();
     while (it != port_cfg_map.end())
@@ -250,7 +254,54 @@ void handlePortConfig(ProducerStateTable &p, map<string, KeyOpFieldsValuesTuple>
             /* No support for port delete yet */
             if (op == SET_COMMAND)
             {
-                p.set(key, values);
+                
+                for (auto i : values)
+                {
+                    auto field = fvField(i);
+                    if (field == "adv_speeds")
+                    {
+                        autoneg_attrs.push_back(i);
+                    }
+                    else if (field == "adv_interface_types")
+                    {
+                        autoneg_attrs.push_back(i);
+                    }
+                    else if (field == "speed")
+                    {
+                        force_attrs.push_back(i);
+                    }
+                    else if (field == "interface_type")
+                    {
+                        force_attrs.push_back(i);
+                    }
+                    else if (field == "autoneg")
+                    {
+                        autoneg = fvValue(i);
+                        attrs.push_back(i);
+                    }
+                    else 
+                    {
+                        attrs.push_back(i);
+                    }
+                }
+                if (autoneg == "on") // autoneg is on, only put adv_speeds and adv_interface_types to APPL_DB
+                {
+                    attrs.insert(attrs.end(), autoneg_attrs.begin(), autoneg_attrs.end());
+                }
+                else if (autoneg == "off") // autoneg is off, only put speed and interface_type to APPL_DB
+                {
+                    attrs.insert(attrs.end(), force_attrs.begin(), force_attrs.end());
+                }
+                else // autoneg is not configured, put all attributes to APPL_DB
+                {
+                    attrs.insert(attrs.end(), autoneg_attrs.begin(), autoneg_attrs.end());
+                    attrs.insert(attrs.end(), force_attrs.begin(), force_attrs.end());
+                }
+                p.set(key, attrs);
+                attrs.clear();
+                autoneg_attrs.clear();
+                force_attrs.clear();
+                autoneg.clear();
             }
 
             it = port_cfg_map.erase(it);


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

Before puting port related configuration to APPL_DB, check autoneg mode first. If autoneg mode is enabled, "speed" and "interface_type" will not be put into APPL_DB; if autoneg mode is disabled, "adv_speeds" and "adv_interface_types" will not be put into APPL_DB; else all configuration will be put to APPL_DB for backward compatible.

**Why I did it**

The field "speed" in PORT_TABLE of APPL_DB has two meanings:
1. The configured port speed
2. The actual port speed

This is all right when SONiC has no auto negotiation feature because the actual speed must equal to the configured speed or the operational status is down. However, with port auto negotiation feature, if autoneg mode is enabled, the actual speed could be a value of adv_speeds which might not equal to field "speed". Now port auto negotiation feature handle it this way: 
1. if autoneg mode  is disabled, everything goes to the old way, the actual speed is always equal to field "speed"; 
2. if autoneg mode is enabled, and if operational status is up, get actual speed from SAI and update the field "speed" in APPL_DB.

For case#2, there is an issue. Think about following flow:
1. Set Ethernet0 speed=400000
2. Set Ethernet0 autoneg=on, adv_speeds=100000, and Ethernet0 is operational up. Now the speed of Ethernet0 in "show interfaces status" is 100G because orchagent get the actual speed from SAI. This is right.
3. Issue command: "config interface type Ethernet0 CR".

Step#3 won't affect the auto negotiation status because the autoneg mode is enabled, force interface type will not be applied to SAI. But it triggers PORT_TABLE change and portsyncd will push all Ethernet0 related configuration to APPL_DB. So, speed of Ethernet0 in "show interface status" changed to 400G.

This PR is to fix the issue.

**How I verified it**

Manual test

**Details if related**
