### PR TITLE
[buffermgrd] Use unix socket for redis connection

### DIFF
--- a/cfgmgr/buffermgrd.cpp
+++ b/cfgmgr/buffermgrd.cpp
@@ -46,7 +46,7 @@ void dump_db_item(KeyOpFieldsValuesTuple &db_item)
 
 void write_to_state_db(shared_ptr<vector<KeyOpFieldsValuesTuple>> db_items_ptr)
 {
-    DBConnector db("STATE_DB", 0, true);
+    DBConnector db("STATE_DB", 0);
     auto &db_items = *db_items_ptr;
     for (auto &db_item : db_items)
     {


### PR DESCRIPTION
**Why I did this?**

Most of the DB connection in buffermgrd is using unix socket. There is only one DB connection which is using TCP socket. It brings a few drawback:

1. TCP socket is less efficiency
2. TCP socket may fail if loopback interface is down. It could cause following error:
```
Apr 29 16:53:25.586513 sonic ERR swss#buffermgrd: :- main: Runtime error: Unable to connect to redis: Cannot assign requested address
```

**How I did this**

Change TCP socket to unix socket

**How I verify this**

Manual test